### PR TITLE
moving org.hsqldb/hsqldb as test dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## 0.1.1
+### Changes
+* Using hsqldb as test dependency prevent us to have hsqldb in production environment

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [microscope "0.1.3"]
-                 [com.mchange/c3p0 "0.9.5.1"]
-                 [org.clojure/java.jdbc "0.6.1"]]
+                 [com.mchange/c3p0 "0.9.5.2"]
+                 [org.clojure/java.jdbc "0.7.0"]]
 
   :profiles {:dev {:src-paths ["dev"]
                    :dependencies [[org.hsqldb/hsqldb "2.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject microscope/relational-db "0.1.1-SNAPSHOT"
+(defproject microscope/relational-db "0.1.1"
   :description "Microservice architecture for Clojure"
   :url "https://github.com/acessocard/microscope"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject microscope/relational-db "0.1.0"
+(defproject microscope/relational-db "0.1.1-SNAPSHOT"
   :description "Microservice architecture for Clojure"
   :url "https://github.com/acessocard/microscope"
   :license {:name "Eclipse Public License"
@@ -6,9 +6,9 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [microscope "0.1.3"]
                  [com.mchange/c3p0 "0.9.5.1"]
-                 [org.clojure/java.jdbc "0.6.1"]
-                 [org.hsqldb/hsqldb "2.4.0"]]
+                 [org.clojure/java.jdbc "0.6.1"]]
 
   :profiles {:dev {:src-paths ["dev"]
-                   :dependencies [[midje "1.8.3"]]
+                   :dependencies [[org.hsqldb/hsqldb "2.4.0"]
+                                  [midje "1.8.3"]]
                    :plugins [[lein-midje "3.2.1"]]}})


### PR DESCRIPTION
Using hsqldb as test dependency prevent us to have hsqldb in production environment